### PR TITLE
Feature param change stop after and keep

### DIFF
--- a/raspicat_navigation_msgs/msg/Flag.msg
+++ b/raspicat_navigation_msgs/msg/Flag.msg
@@ -2,3 +2,4 @@ bool restart
 bool goal_reach
 bool slope
 bool param_change
+bool stop_after_and_keep

--- a/raspicat_waypoint_navigation/config/waypoint/waypoint_tsudanuma_2_19.yaml
+++ b/raspicat_waypoint_navigation/config/waypoint/waypoint_tsudanuma_2_19.yaml
@@ -8,15 +8,18 @@ waypoints:
     properties:
       - function: slope
         slope_circle_area: 3.0
+      - function: stop
       - function: param_change
         param_name: /move_base/DWAPlannerROS/max_vel_x
-        param_value: "0.8"
+        param_value: "0.3"
       - function: param_change
         param_name: /move_base/DWAPlannerROS/max_vel_trans
-        param_value: "0.8"
+        param_value: "0.3"
       - function: param_change
         param_name: /move_base/local_costmap/obstacles_layer/enabled
         param_value: "false"
+      - function: param_change
+        stop_after_and_keep: true
   - id: 2
     position:
       x: 19.975597
@@ -29,6 +32,8 @@ waypoints:
       - function: attention_speak
       - function: variable_waypoint_radius
         waypoint_radius: 1.0
+      - function: param_change
+        stop_after_and_keep: true
   - id: 3
     position:
       x: 14.3

--- a/raspicat_waypoint_navigation/include/raspicat_waypoint_navigation/ParamChange.hpp
+++ b/raspicat_waypoint_navigation/include/raspicat_waypoint_navigation/ParamChange.hpp
@@ -36,6 +36,7 @@ class ParamChange : public raspicat_navigation::WaypointNavHelperPlugin
   std::vector<std::string> splitSlash(const std::string str);
   std::string getNodeFromString(const std::vector<std::string> vec);
   std::string getParamFromString(const std::vector<std::string> vec);
+  bool checkElementDuplication(const std::string str, const std::vector<std::string> vec);
 };
 
 }  // namespace raspicat_navigation

--- a/raspicat_waypoint_navigation/include/raspicat_waypoint_navigation/WaypointServer.hpp
+++ b/raspicat_waypoint_navigation/include/raspicat_waypoint_navigation/WaypointServer.hpp
@@ -68,6 +68,7 @@ class WaypointServer : public raspicat_navigation::BaseWaypointServer
   void eraseTimer(raspicat_navigation_msgs::WaypointNavStatus &WaypointNavStatus,
                   std::map<std::string, ros::Timer> &timer_for_function);
 
+  bool checkElementDuplication(const std::string str, const std::vector<std::string> vec);
   void saveParam(raspicat_navigation_msgs::WaypointNavStatus &WaypointNavStatus);
   std::string getParam(raspicat_navigation_msgs::WaypointNavStatus &WaypointNavStatus);
   void clearSaveParam(raspicat_navigation_msgs::WaypointNavStatus &WaypointNavStatus);

--- a/raspicat_waypoint_navigation/src/WaypointServer.cpp
+++ b/raspicat_waypoint_navigation/src/WaypointServer.cpp
@@ -270,6 +270,12 @@ std::string WaypointServer::getParam(raspicat_navigation_msgs::WaypointNavStatus
   }
 }
 
+bool WaypointServer::checkElementDuplication(const std::string str,
+                                             const std::vector<std::string> vec)
+{
+  return std::find(vec.begin(), vec.end(), str) != vec.end();
+}
+
 void WaypointServer::saveParam(raspicat_navigation_msgs::WaypointNavStatus &WaypointNavStatus)
 {
   WaypointNavStatus.servers.param_change.param_name_save.push_back(
@@ -368,9 +374,16 @@ void WaypointServer::setWaypointFunction(
             WaypointNavStatus.functions.param_change.param_value.push_back(
                 static_cast<string>(waypoint_yaml[WaypointNavStatus.waypoint_current_id]
                                                  ["properties"][i]["param_value"]));
-
-            saveParam(WaypointNavStatus);
+            if (not checkElementDuplication(
+                    static_cast<string>(waypoint_yaml[WaypointNavStatus.waypoint_current_id]
+                                                     ["properties"][i]["param_name"]),
+                    WaypointNavStatus.servers.param_change.param_name_save))
+              saveParam(WaypointNavStatus);
           }
+
+          if (static_cast<bool>(waypoint_yaml[WaypointNavStatus.waypoint_current_id]["properties"]
+                                             [i]["stop_after_and_keep"]))
+            WaypointNavStatus.flags.stop_after_and_keep = true;
         }
       }
 


### PR DESCRIPTION
* CPU処理能力的に停止時にパラメータを変更するのが良さそうなので実装した
* パラメータの変更を継続できるようにもした 

例
```
waypoints:
  - id: 1
    position:
      x: 7.749710
      y: -0.362790
    euler_angle:
      z: -0.0638248225954985
    properties:
      - function: slope
        slope_circle_area: 3.0
      - function: stop
      - function: param_change
        param_name: /move_base/DWAPlannerROS/max_vel_x
        param_value: "0.3"
      - function: param_change
        param_name: /move_base/DWAPlannerROS/max_vel_trans
        param_value: "0.3"
      - function: param_change
        param_name: /move_base/local_costmap/obstacles_layer/enabled
        param_value: "false"
      - function: param_change
        stop_after_and_keep: true
  - id: 2
    position:
      x: 19.975597
      y: -0.901446
    euler_angle:
      z: 1.502107171059494
    properties:
      - function: slope
        slope_circle_area: 3.0
      - function: attention_speak
      - function: variable_waypoint_radius
        waypoint_radius: 1.0
      - function: param_change
        stop_after_and_keep: true
```