### PR TITLE
Feature/raspicat raspi only navigation on vsim

### DIFF
--- a/raspicat_waypoint_navigation/launch/raspicat_raspi_only_navigation.launch
+++ b/raspicat_waypoint_navigation/launch/raspicat_raspi_only_navigation.launch
@@ -21,7 +21,7 @@
   <arg name="move_base_map_file"    default="$(find raspicat_waypoint_navigation)/config/maps/for_move_base/map_$(arg world_name).yaml"/>
   <arg name="waypoint_yaml_file"    default="$(find raspicat_waypoint_navigation)/config/waypoint/waypoint_$(arg world_name).yaml"/>
 
-  <arg name="mcl"                   default="amcl" doc="model type [amcl, emcl2, mcl_ros]"/>
+  <arg name="mcl"                   default="emcl2" doc="model type [amcl, emcl2, mcl_ros]"/>
   <arg name="mcl_init_pose_x"       default="0.0"/>
   <arg name="mcl_init_pose_y"       default="0.0"/>
   <arg name="mcl_init_pose_a"       default="0.0"/>

--- a/raspicat_waypoint_navigation/launch/sim/raspicat_navigation_vsim.launch
+++ b/raspicat_waypoint_navigation/launch/sim/raspicat_navigation_vsim.launch
@@ -11,7 +11,7 @@
   <arg name="mcl_map_file"        default="$(find raspicat_waypoint_navigation)/config/maps/$(arg world_name)/map_$(arg world_name).yaml"/>
   <arg name="move_base_map_file"  default="$(find raspicat_waypoint_navigation)/config/maps/for_move_base/map_$(arg world_name).yaml"/>
   <arg name="waypoint_yaml_file"  default="$(find raspicat_waypoint_navigation)/config/waypoint/waypoint_$(arg world_name).yaml"/>
-  <arg name="mcl"                 default="amcl" doc="model type [amcl, emcl2, mcl_ros]"/>
+  <arg name="mcl"                 default="emcl2" doc="model type [amcl, emcl2, mcl_ros]"/>
 
   <arg name="cmd_vel_out" default="/cmd_vel"/>
   <arg name="config_topics" default="$(find raspicat_waypoint_navigation)/config/param/twist_mux_topics.yaml"/>

--- a/raspicat_waypoint_navigation/launch/sim/raspicat_raspi_only_navigation_on_vsim.launch
+++ b/raspicat_waypoint_navigation/launch/sim/raspicat_raspi_only_navigation_on_vsim.launch
@@ -29,14 +29,14 @@
     <arg name="a_mcl"       default="-0.013"/>
 
     <!-- Gazebo -->
-    <include if="$(eval pc=='true')" file="$(find raspicat_map2gazebo)/launch/raspicat_$(arg world_name)_world.launch">
+    <include if="$(arg pc)" file="$(find raspicat_map2gazebo)/launch/raspicat_$(arg world_name)_world.launch">
       <arg name="x_init_pos"    value="$(arg x_gazebo)"/>
       <arg name="y_init_pos"    value="$(arg y_gazebo)"/>
       <arg name="yaw_init_pos"  value="$(arg yaw_gazebo)"/>
       <arg name="open_gui"      value="$(arg open_gazebo)"/>
     </include>
     
-    <group if="$(eval raspi=='true')">
+    <group if="$(arg raspi)">
       <!-- Amcl -->
       <group if="$(eval mcl=='amcl')">
         <include file="$(find raspicat_waypoint_navigation)/launch/amcl.launch">
@@ -76,14 +76,14 @@
     <arg name="a_mcl"       default="1.626"/>
 
     <!-- Gazebo -->
-    <include if="$(eval pc=='true')" file="$(find raspicat_map2gazebo)/launch/raspicat_$(arg world_name)_world.launch">
+    <include if="$(arg pc)" file="$(find raspicat_map2gazebo)/launch/raspicat_$(arg world_name)_world.launch">
       <arg name="x_init_pos"    value="$(arg x_gazebo)"/>
       <arg name="y_init_pos"    value="$(arg y_gazebo)"/>
       <arg name="yaw_init_pos"  value="$(arg yaw_gazebo)"/>
       <arg name="open_gui"      value="$(arg open_gazebo)"/>
     </include>
     
-    <group if="$(eval raspi=='true')">
+    <group if="$(arg raspi)">
       <!-- Amcl -->
       <group if="$(eval mcl=='amcl')">
         <include file="$(find raspicat_waypoint_navigation)/launch/amcl.launch">
@@ -123,14 +123,14 @@
     <arg name="a_mcl"       default="0.0"/>
 
     <!-- Gazebo -->
-    <include if="$(eval pc=='true')" file="$(find raspicat_map2gazebo)/launch/raspicat_$(arg world_name)_world.launch">
+    <include if="$(arg pc)" file="$(find raspicat_map2gazebo)/launch/raspicat_$(arg world_name)_world.launch">
       <arg name="x_init_pos"    value="$(arg x_gazebo)"/>
       <arg name="y_init_pos"    value="$(arg y_gazebo)"/>
       <arg name="yaw_init_pos"  value="$(arg yaw_gazebo)"/>
       <arg name="open_gui"      value="$(arg open_gazebo)"/>
     </include>
     
-    <group if="$(eval raspi=='true')">
+    <group if="$(arg raspi)">
       <!-- Amcl -->
       <group if="$(eval mcl=='amcl')">
         <include file="$(find raspicat_waypoint_navigation)/launch/amcl.launch">
@@ -159,7 +159,7 @@
     </group>
   </group>
 
-  <group if="$(eval raspi=='true')">
+  <group if="$(arg raspi)">
     <!-- Map_server -->
     <node pkg="map_server" name="mcl_map_server" type="map_server" args="$(arg mcl_map_file)"/>
 

--- a/raspicat_waypoint_navigation/launch/sim/raspicat_raspi_only_navigation_on_vsim.launch
+++ b/raspicat_waypoint_navigation/launch/sim/raspicat_raspi_only_navigation_on_vsim.launch
@@ -1,0 +1,190 @@
+<?xml version="1.0"?>
+<launch>
+  <!-- Arguments -->
+  <arg name="pc"           default="false"/>
+  <arg name="raspi"        default="false"/>
+
+  <arg name="open_gazebo"         default="true"/>
+
+  <arg name="move_forward_only"   default="false"/>
+  <arg name="waypoint_navigation" default="true"/>
+
+  <arg name="world_name"          default="tsudanuma_2_19" doc="world_name type [tsudanuma_2_19, tsudanuma, tsukuba]"/>
+  <arg name="mcl_map_file"        default="$(find raspicat_waypoint_navigation)/config/maps/$(arg world_name)/map_$(arg world_name).yaml"/>
+  <arg name="move_base_map_file"  default="$(find raspicat_waypoint_navigation)/config/maps/for_move_base/map_$(arg world_name).yaml"/>
+  <arg name="waypoint_yaml_file"  default="$(find raspicat_waypoint_navigation)/config/waypoint/waypoint_$(arg world_name).yaml"/>
+  <arg name="mcl"                 default="emcl2" doc="model type [amcl, emcl2, mcl_ros]"/>
+
+  <arg name="cmd_vel_out" default="/cmd_vel"/>
+  <arg name="config_topics" default="$(find raspicat_waypoint_navigation)/config/param/twist_mux_topics.yaml"/>
+
+  <!-- Tsudanuma 2 19 -->
+  <group if="$(eval world_name=='tsudanuma_2_19')">
+    <arg name="x_gazebo"    default="0.155971128532"/>
+    <arg name="y_gazebo"    default="-0.0254326737864"/>
+    <arg name="yaw_gazebo"  default="0"/>
+
+    <arg name="x_mcl"       default="-0.309"/>
+    <arg name="y_mcl"       default="0.112"/>
+    <arg name="a_mcl"       default="-0.013"/>
+
+    <!-- Gazebo -->
+    <include if="$(eval pc=='true')" file="$(find raspicat_map2gazebo)/launch/raspicat_$(arg world_name)_world.launch">
+      <arg name="x_init_pos"    value="$(arg x_gazebo)"/>
+      <arg name="y_init_pos"    value="$(arg y_gazebo)"/>
+      <arg name="yaw_init_pos"  value="$(arg yaw_gazebo)"/>
+      <arg name="open_gui"      value="$(arg open_gazebo)"/>
+    </include>
+    
+    <group if="$(eval raspi=='true')">
+      <!-- Amcl -->
+      <group if="$(eval mcl=='amcl')">
+        <include file="$(find raspicat_waypoint_navigation)/launch/amcl.launch">
+          <arg name="initial_pose_x"  value="$(arg x_mcl)"/>
+          <arg name="initial_pose_y"  value="$(arg y_mcl)"/>
+          <arg name="initial_pose_a"  value="$(arg a_mcl)"/>
+        </include>
+      </group>
+
+      <!-- Emcl2 -->
+      <group if="$(eval mcl=='emcl2')">
+        <include file="$(find raspicat_waypoint_navigation)/launch/emcl2.launch">
+          <arg name="initial_pose_x"  value="$(arg x_mcl)"/>
+          <arg name="initial_pose_y"  value="$(arg y_mcl)"/>
+          <arg name="initial_pose_a"  value="$(arg a_mcl)"/>
+        </include>
+      </group>
+
+      <!-- Waypoint_nav -->
+      <node if="$(arg waypoint_navigation)" pkg="raspicat_waypoint_navigation" name="WaypointNav_node" type="WaypointNav_node" output="screen">
+        <rosparam command="load" file="$(arg waypoint_yaml_file)"/>
+        <param name="initial_pose_x"  value="$(arg x_mcl)"/>
+        <param name="initial_pose_y"  value="$(arg y_mcl)"/>
+        <param name="initial_pose_a"  value="$(arg a_mcl)"/>
+      </node>
+    </group>
+  </group>
+
+  <!-- Tsudanuma -->
+  <group if="$(eval world_name=='tsudanuma')">
+    <arg name="x_gazebo"    default="58.1535747159"/>
+    <arg name="y_gazebo"    default="-64.2634867703"/>
+    <arg name="yaw_gazebo"  default="1.5"/>
+
+    <arg name="x_mcl"       default="-10.352"/>
+    <arg name="y_mcl"       default="-69.350"/>
+    <arg name="a_mcl"       default="1.626"/>
+
+    <!-- Gazebo -->
+    <include if="$(eval pc=='true')" file="$(find raspicat_map2gazebo)/launch/raspicat_$(arg world_name)_world.launch">
+      <arg name="x_init_pos"    value="$(arg x_gazebo)"/>
+      <arg name="y_init_pos"    value="$(arg y_gazebo)"/>
+      <arg name="yaw_init_pos"  value="$(arg yaw_gazebo)"/>
+      <arg name="open_gui"      value="$(arg open_gazebo)"/>
+    </include>
+    
+    <group if="$(eval raspi=='true')">
+      <!-- Amcl -->
+      <group if="$(eval mcl=='amcl')">
+        <include file="$(find raspicat_waypoint_navigation)/launch/amcl.launch">
+          <arg name="initial_pose_x"  value="$(arg x_mcl)"/>
+          <arg name="initial_pose_y"  value="$(arg y_mcl)"/>
+          <arg name="initial_pose_a"  value="$(arg a_mcl)"/>
+        </include>
+      </group>
+
+      <!-- Emcl2 -->
+      <group if="$(eval mcl=='emcl2')">
+        <include file="$(find raspicat_waypoint_navigation)/launch/emcl2.launch">
+          <arg name="initial_pose_x"  value="$(arg x_mcl)"/>
+          <arg name="initial_pose_y"  value="$(arg y_mcl)"/>
+          <arg name="initial_pose_a"  value="$(arg a_mcl)"/>
+        </include>
+      </group>
+
+      <!-- Waypoint_nav -->
+      <node if="$(arg waypoint_navigation)" pkg="raspicat_waypoint_navigation" name="WaypointNav_node" type="WaypointNav_node" output="screen">
+        <rosparam command="load" file="$(arg waypoint_yaml_file)"/>
+        <param name="initial_pose_x"  value="$(arg x_mcl)"/>
+        <param name="initial_pose_y"  value="$(arg y_mcl)"/>
+        <param name="initial_pose_a"  value="$(arg a_mcl)"/>
+      </node>
+    </group>
+  </group>
+
+  <!-- Tsukuba -->
+  <group if="$(eval world_name=='tsukuba')">
+    <arg name="x_gazebo"    default="453.042544981"/>
+    <arg name="y_gazebo"    default="-39.4949665659"/>
+    <arg name="yaw_gazebo"  default="0.0"/>
+
+    <arg name="x_mcl"       default="0.0"/>
+    <arg name="y_mcl"       default="0.0"/>
+    <arg name="a_mcl"       default="0.0"/>
+
+    <!-- Gazebo -->
+    <include if="$(eval pc=='true')" file="$(find raspicat_map2gazebo)/launch/raspicat_$(arg world_name)_world.launch">
+      <arg name="x_init_pos"    value="$(arg x_gazebo)"/>
+      <arg name="y_init_pos"    value="$(arg y_gazebo)"/>
+      <arg name="yaw_init_pos"  value="$(arg yaw_gazebo)"/>
+      <arg name="open_gui"      value="$(arg open_gazebo)"/>
+    </include>
+    
+    <group if="$(eval raspi=='true')">
+      <!-- Amcl -->
+      <group if="$(eval mcl=='amcl')">
+        <include file="$(find raspicat_waypoint_navigation)/launch/amcl.launch">
+          <arg name="initial_pose_x"  value="$(arg x_mcl)"/>
+          <arg name="initial_pose_y"  value="$(arg y_mcl)"/>
+          <arg name="initial_pose_a"  value="$(arg a_mcl)"/>
+        </include>
+      </group>
+
+      <!-- Emcl2 -->
+      <group if="$(eval mcl=='emcl2')">
+        <include file="$(find raspicat_waypoint_navigation)/launch/emcl2.launch">
+          <arg name="initial_pose_x"  value="$(arg x_mcl)"/>
+          <arg name="initial_pose_y"  value="$(arg y_mcl)"/>
+          <arg name="initial_pose_a"  value="$(arg a_mcl)"/>
+        </include>
+      </group>
+
+      <!-- Waypoint_nav -->
+      <node if="$(arg waypoint_navigation)" pkg="raspicat_waypoint_navigation" name="WaypointNav_node" type="WaypointNav_node" output="screen">
+        <rosparam command="load" file="$(arg waypoint_yaml_file)"/>
+        <param name="initial_pose_x"  value="$(arg x_mcl)"/>
+        <param name="initial_pose_y"  value="$(arg y_mcl)"/>
+        <param name="initial_pose_a"  value="$(arg a_mcl)"/>
+      </node>
+    </group>
+  </group>
+
+  <group if="$(eval raspi=='true')">
+    <!-- Map_server -->
+    <node pkg="map_server" name="mcl_map_server" type="map_server" args="$(arg mcl_map_file)"/>
+
+    <node pkg="map_server" name="move_base_map_server" type="map_server" args="$(arg move_base_map_file)">
+      <remap from="map" to="/move_base_map"/>
+      <remap from="static_map" to="/move_base_static_map"/>
+    </node>
+
+    <!-- Move_base -->
+    <include file="$(find raspicat_waypoint_navigation)/launch/move_base.launch">
+      <arg name="move_forward_only" value="$(arg move_forward_only)"/>
+      <arg name="waypoint_nav" default="$(arg waypoint_navigation)"/>
+    </include>
+
+    <!-- Raspicat speak -->
+    <node pkg="raspicat_speak" type="raspicat_speak_node" name="raspicat_speak_node" 
+          clear_params="true" respawn="true" output="screen">
+      <rosparam command="load" file="$(find raspicat_waypoint_navigation)/config/raspicat_speak/speak_list.yaml"/>
+      <rosparam command="load" file="$(find raspicat_waypoint_navigation)/config/raspicat_speak/voice_config.yaml"/>
+    </node>
+
+    <!-- Twist mux -->
+    <node pkg="twist_mux" type="twist_mux" name="twist_mux" output="screen">
+      <remap from="cmd_vel_out" to="$(arg cmd_vel_out)"/>
+      <rosparam file="$(arg config_topics)" command="load"/>
+    </node>
+  </group>
+</launch>

--- a/raspicat_waypoint_navigation/launch/sim/raspicat_raspi_only_navigation_on_vsim.launch
+++ b/raspicat_waypoint_navigation/launch/sim/raspicat_raspi_only_navigation_on_vsim.launch
@@ -18,6 +18,9 @@
   <arg name="cmd_vel_out" default="/cmd_vel"/>
   <arg name="config_topics" default="$(find raspicat_waypoint_navigation)/config/param/twist_mux_topics.yaml"/>
 
+	<!-- Parameters -->
+  <param name="/use_sim_time" value="true"/>
+
   <!-- Tsudanuma 2 19 -->
   <group if="$(eval world_name=='tsudanuma_2_19')">
     <arg name="x_gazebo"    default="0.155971128532"/>


### PR DESCRIPTION
* raspiのCPUを使って実際にナビゲーションを行うための実装

デスクトップPCやラップトップPCが別途必要
優先LANで接続する必要がある（低遅延のために）

raspiではナビゲーション周りの立ち上げ
PCはシミュレータの立ち上げ

実際の処理不可でシミュレーションができるので
現地に行かなくても、処理時間によるミス等の早期発見が期待できる